### PR TITLE
Replace Flask-AQLAlchemy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project demonstrates a simple Domain Driven Design (DDD) structure for a Fl
 
 ## Setup
 
-Install dependencies and run the application:
+Install dependencies (which include Flask-SQLAlchemy) and run the application:
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.0
-Flask-AQLAlchemy==3.1.1
+Flask-SQLAlchemy==3.1.1
 Flask-Cors==3.0.10
 Werkzeug==2.3.0
 Flask-Migrate==4.0.4


### PR DESCRIPTION
## Summary
- replace Flask-AQLAlchemy with Flask-SQLAlchemy in requirements
- clarify README installation instructions to mention Flask-SQLAlchemy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e3fcbb98832cb352e1d7ac2f56b5