### PR TITLE
Add dataclass entities and move SQLAlchemy models

### DIFF
--- a/app/adapters/sqlalchemy/models.py
+++ b/app/adapters/sqlalchemy/models.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from ...extensions import db
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+
+class Product(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    price = db.Column(db.Float, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/app/domain/entities.py
+++ b/app/domain/entities.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class User:
+    id: Optional[int] = None
+    username: str = ""
+    password_hash: str = ""
+
+
+@dataclass
+class Product:
+    id: Optional[int] = None
+    name: str = ""
+    price: float = 0.0
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/app/domain/models.py
+++ b/app/domain/models.py
@@ -1,15 +1,5 @@
-from datetime import datetime
-from ..extensions import db
+"""Backward compatibility module for SQLAlchemy models."""
 
+from ..adapters.sqlalchemy.models import User, Product
 
-class User(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(80), unique=True, nullable=False)
-    password_hash = db.Column(db.String(128), nullable=False)
-
-
-class Product(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(120), nullable=False)
-    price = db.Column(db.Float, nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+__all__ = ["User", "Product"]

--- a/app/domain/repositories.py
+++ b/app/domain/repositories.py
@@ -1,4 +1,4 @@
-from .models import User, Product
+from ..adapters.sqlalchemy.models import User, Product
 from ..extensions import db
 
 

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -4,7 +4,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from flask import current_app, request, jsonify
 from functools import wraps
 
-from ..domain.models import User
+from ..adapters.sqlalchemy.models import User
 from ..domain.repositories import UserRepository
 
 

--- a/app/services/product_service.py
+++ b/app/services/product_service.py
@@ -1,4 +1,4 @@
-from ..domain.models import Product
+from ..adapters.sqlalchemy.models import Product
 from ..domain.repositories import ProductRepository
 
 


### PR DESCRIPTION
## Summary
- introduce `User` and `Product` entity dataclasses
- move SQLAlchemy models to `app/adapters/sqlalchemy/models.py`
- adjust imports to new location while keeping a compatibility module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e4d0af48832c9ffad127ef16c5b0