### PR TITLE
Refactor domain repositories into interfaces

### DIFF
--- a/app/adapters/sqlalchemy/repositories.py
+++ b/app/adapters/sqlalchemy/repositories.py
@@ -1,0 +1,41 @@
+from ...extensions import db
+from .models import User, Product
+from ...domain.repositories import (
+    UserRepositoryInterface,
+    ProductRepositoryInterface,
+)
+
+
+class UserRepository(UserRepositoryInterface):
+    """SQLAlchemy-backed user repository."""
+
+    @staticmethod
+    def get_by_username(username: str) -> User | None:
+        return User.query.filter_by(username=username).first()
+
+    @staticmethod
+    def add(user: User) -> None:
+        db.session.add(user)
+        db.session.commit()
+
+
+class ProductRepository(ProductRepositoryInterface):
+    """SQLAlchemy-backed product repository."""
+
+    @staticmethod
+    def all() -> list[Product]:
+        return Product.query.all()
+
+    @staticmethod
+    def get(product_id: int) -> Product | None:
+        return Product.query.get(product_id)
+
+    @staticmethod
+    def add(product: Product) -> None:
+        db.session.add(product)
+        db.session.commit()
+
+    @staticmethod
+    def delete(product: Product) -> None:
+        db.session.delete(product)
+        db.session.commit()

--- a/app/controllers/product_controller.py
+++ b/app/controllers/product_controller.py
@@ -2,7 +2,7 @@ from flask import Blueprint, request, jsonify
 
 from ..services.product_service import ProductService
 from ..services.auth_service import jwt_required
-from ..domain.repositories import ProductRepository
+from ..adapters.sqlalchemy.repositories import ProductRepository
 
 product_bp = Blueprint('product', __name__)
 

--- a/app/domain/repositories.py
+++ b/app/domain/repositories.py
@@ -1,33 +1,31 @@
-from ..adapters.sqlalchemy.models import User, Product
-from ..extensions import db
+"""Repository interface definitions for the domain layer."""
+
+from typing import Iterable, Optional, Protocol
+
+from .entities import Product, User
 
 
-class UserRepository:
-    @staticmethod
-    def get_by_username(username: str):
-        return User.query.filter_by(username=username).first()
+class UserRepositoryInterface(Protocol):
+    """Interface for user persistence operations."""
 
-    @staticmethod
-    def add(user: User):
-        db.session.add(user)
-        db.session.commit()
+    def get_by_username(self, username: str) -> Optional[User]:
+        """Return a user by its username or ``None`` if not found."""
+
+    def add(self, user: User) -> None:
+        """Persist a ``User`` instance."""
 
 
-class ProductRepository:
-    @staticmethod
-    def all():
-        return Product.query.all()
+class ProductRepositoryInterface(Protocol):
+    """Interface for product persistence operations."""
 
-    @staticmethod
-    def get(product_id: int):
-        return Product.query.get(product_id)
+    def all(self) -> Iterable[Product]:
+        """Return all stored products."""
 
-    @staticmethod
-    def add(product: Product):
-        db.session.add(product)
-        db.session.commit()
+    def get(self, product_id: int) -> Optional[Product]:
+        """Return a product by id or ``None`` if it does not exist."""
 
-    @staticmethod
-    def delete(product: Product):
-        db.session.delete(product)
-        db.session.commit()
+    def add(self, product: Product) -> None:
+        """Persist a ``Product`` instance."""
+
+    def delete(self, product: Product) -> None:
+        """Remove a ``Product`` instance."""

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -5,7 +5,7 @@ from flask import current_app, request, jsonify
 from functools import wraps
 
 from ..adapters.sqlalchemy.models import User
-from ..domain.repositories import UserRepository
+from ..adapters.sqlalchemy.repositories import UserRepository
 
 
 class AuthService:

--- a/app/services/product_service.py
+++ b/app/services/product_service.py
@@ -1,5 +1,5 @@
 from ..adapters.sqlalchemy.models import Product
-from ..domain.repositories import ProductRepository
+from ..adapters.sqlalchemy.repositories import ProductRepository
 
 
 class ProductService:


### PR DESCRIPTION
## Summary
- replace concrete repositories in `app/domain/repositories.py` with protocol-based interfaces
- implement SQLAlchemy-specific repositories in `app/adapters/sqlalchemy/repositories.py`
- update service and controller imports to use new location

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e6028254832c9d388ea3a6089cd5