### PR TITLE
Add memory-based tests for services

### DIFF
--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,0 +1,53 @@
+import jwt
+from flask import Flask
+
+from app.services.auth_service import AuthService
+from app.domain.entities import User
+from app.domain.repositories import UserRepositoryInterface
+
+
+class FakeUserRepository(UserRepositoryInterface):
+    def __init__(self):
+        self.users = {}
+        self.next_id = 1
+
+    def get_by_username(self, username: str):
+        for user in self.users.values():
+            if user.username == username:
+                return user
+        return None
+
+    def add(self, user: User) -> None:
+        if user.id is None:
+            user.id = self.next_id
+            self.next_id += 1
+        self.users[user.id] = User(
+            id=user.id,
+            username=user.username,
+            password_hash=user.password_hash,
+        )
+
+
+def create_service():
+    repo = FakeUserRepository()
+    service = AuthService(repo)
+    app = Flask(__name__)
+    app.config['JWT_SECRET_KEY'] = 'test-secret'
+    return service, repo, app
+
+
+def test_register_and_authenticate():
+    service, repo, app = create_service()
+    with app.app_context():
+        user = service.register('bob', 'pass')
+        assert user.id == 1
+        assert repo.get_by_username('bob') is not None
+        assert user.password_hash != 'pass'
+
+        token = service.authenticate('bob', 'pass')
+        assert token
+        payload = jwt.decode(token, app.config['JWT_SECRET_KEY'], algorithms=['HS256'])
+        assert payload['sub'] == user.id
+
+        assert service.authenticate('bob', 'wrong') is None
+        assert service.register('bob', 'pass') is None

--- a/tests/test_product_service.py
+++ b/tests/test_product_service.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from app.services.product_service import ProductService
+from app.domain.entities import Product
+from app.domain.repositories import ProductRepositoryInterface
+
+
+class FakeProductRepository(ProductRepositoryInterface):
+    def __init__(self):
+        self.products = {}
+        self.next_id = 1
+
+    def all(self):
+        return list(self.products.values())
+
+    def get(self, product_id: int):
+        return self.products.get(product_id)
+
+    def add(self, product: Product) -> None:
+        if product.id is None:
+            product.id = self.next_id
+            self.next_id += 1
+            if product.created_at is None:
+                product.created_at = datetime.utcnow()
+        self.products[product.id] = Product(
+            id=product.id,
+            name=product.name,
+            price=product.price,
+            created_at=product.created_at,
+        )
+
+    def delete(self, product: Product) -> None:
+        self.products.pop(product.id, None)
+
+
+def test_product_crud_operations():
+    repo = FakeProductRepository()
+    service = ProductService(repo)
+
+    product = service.create('Widget', 9.99)
+    assert product.id == 1
+    assert repo.get(product.id) == product
+    assert len(repo.all()) == 1
+
+    product = service.update(product, 'Gadget', 19.99)
+    stored = repo.get(product.id)
+    assert stored.name == 'Gadget'
+    assert stored.price == 19.99
+
+    service.delete(product)
+    assert repo.all() == []


### PR DESCRIPTION
## Summary
- add tests using in-memory repositories for `AuthService` and `ProductService`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt' and 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6866e8462888832c92196bb9a84fb2f6