### PR TITLE
Add docstrings for API controllers

### DIFF
--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -6,6 +6,13 @@ auth_bp = Blueprint('auth', __name__)
 
 @auth_bp.route('/register', methods=['POST'])
 def register():
+    """Create a new user and return a success message.
+
+    Expects ``username`` and ``password`` fields in the JSON body.
+
+    Returns a tuple ``(response, status_code)`` with ``201`` when the user is
+    created or ``400`` if the user already exists.
+    """
     data = request.get_json() or {}
     username = data.get('username')
     password = data.get('password')
@@ -17,6 +24,13 @@ def register():
 
 @auth_bp.route('/login', methods=['POST'])
 def login():
+    """Authenticate a user and return a JWT token.
+
+    The request body should contain ``username`` and ``password`` fields.
+
+    Returns the generated token in JSON format or ``401`` when credentials are
+    invalid.
+    """
     data = request.get_json() or {}
     username = data.get('username')
     password = data.get('password')

--- a/app/controllers/product_controller.py
+++ b/app/controllers/product_controller.py
@@ -8,6 +8,7 @@ product_bp = Blueprint('product', __name__)
 @product_bp.route('/', methods=['GET'])
 @jwt_required
 def index():
+    """Return a JSON list with all stored products."""
     products = current_app.product_service.product_repository.all()
     data = [{'id': p.id, 'name': p.name, 'price': p.price} for p in products]
     return jsonify(data)
@@ -16,6 +17,19 @@ def index():
 @product_bp.route('/<int:product_id>', methods=['GET'])
 @jwt_required
 def show(product_id):
+    """Return details for a single product.
+
+    Parameters
+    ----------
+    product_id: int
+        Identifier of the product to retrieve.
+
+    Returns
+    -------
+    Response
+        JSON representation of the product or a ``404`` message if it does not
+        exist.
+    """
     product = current_app.product_service.get(product_id)
     if product:
         return jsonify({'id': product.id, 'name': product.name, 'price': product.price})
@@ -25,6 +39,15 @@ def show(product_id):
 @product_bp.route('/', methods=['POST'])
 @jwt_required
 def create():
+    """Create a new product from the request JSON body.
+
+    The body must provide ``name`` and ``price`` fields.
+
+    Returns
+    -------
+    Response
+        JSON representation of the new product with a ``201`` status code.
+    """
     data = request.get_json() or {}
     product = current_app.product_service.create(data.get('name'), data.get('price'))
     return jsonify({'id': product.id, 'name': product.name, 'price': product.price}), 201
@@ -33,6 +56,18 @@ def create():
 @product_bp.route('/<int:product_id>', methods=['PUT'])
 @jwt_required
 def update(product_id):
+    """Update an existing product using values from the request body.
+
+    Parameters
+    ----------
+    product_id: int
+        Identifier of the product to update.
+
+    Returns
+    -------
+    Response
+        The updated product in JSON format or ``404`` if it does not exist.
+    """
     product = current_app.product_service.get(product_id)
     if not product:
         return jsonify({'message': 'Not found'}), 404
@@ -44,6 +79,7 @@ def update(product_id):
 @product_bp.route('/<int:product_id>', methods=['DELETE'])
 @jwt_required
 def delete(product_id):
+    """Remove a product by its identifier."""
     product = current_app.product_service.get(product_id)
     if not product:
         return jsonify({'message': 'Not found'}), 404


### PR DESCRIPTION
## Summary
- document user registration and login controller functions
- add docstrings describing product controller endpoints

## Testing
- `pytest -q` *(fails: No module named 'jwt', 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6866eba36a88832c88796ac579315c95