### PR TITLE
Add Swagger integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ python -m flask db upgrade  # run migrations
 python -m app.main
 ```
 
+After running the application you can access the interactive API documentation
+provided by Swagger at `http://localhost:5000/apidocs/`.
+
 ## Arquitetura
 
 Este projeto segue uma separação em três camadas principais (domínio, serviços e adapters).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flasgger import Swagger
 from .config import Config
 from .extensions import db, migrate, cors
 from .controllers import register_controllers
@@ -14,6 +15,7 @@ def create_app():
     db.init_app(app)
     migrate.init_app(app, db)
     cors.init_app(app)
+    Swagger(app)
 
     # Set up repositories and services
     user_repo = UserRepository()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-Cors==3.0.10
 Werkzeug==2.3.0
 Flask-Migrate==4.0.4
 PyJWT==2.6.0
+flasgger==0.9.5


### PR DESCRIPTION
## Summary
- enable Swagger UI using flasgger
- document how to access Swagger docs in README
- add flasgger dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6866efd6d6c0832cb27ea2fe696232b3