### PR TITLE
Configure MySQL settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ python -m app.main
 After running the application you can access the interactive API documentation
 provided by Swagger at `http://localhost:5000/apidocs/`.
 
+### Configuração com MySQL
+
+A aplicação foi preparada para usar o MySQL como banco de dados padrão. Os
+detalhes de conexão podem ser ajustados por meio das seguintes variáveis de
+ambiente:
+
+- `DB_HOST` (padrão `localhost`)
+- `DB_PORT` (padrão `3306`)
+- `DB_USER` (padrão `user`)
+- `DB_PASSWORD` (padrão `password`)
+- `DB_NAME` (padrão `appdb`)
+
+Você também pode definir `DATABASE_URI` com a URI completa de conexão. O arquivo
+`docker-compose.yml` já fornece essas variáveis e sobe um contêiner MySQL pronto
+para uso.
+
 ## Arquitetura
 
 Este projeto segue uma separação em três camadas principais (domínio, serviços e adapters).

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,18 @@
 import os
 
 class Config:
-    SECRET_KEY = os.getenv('SECRET_KEY', 'secret-key')
-    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URI', 'sqlite:///app.db')
+    SECRET_KEY = os.getenv("SECRET_KEY", "secret-key")
+
+    DB_USER = os.getenv("DB_USER", "user")
+    DB_PASSWORD = os.getenv("DB_PASSWORD", "password")
+    DB_HOST = os.getenv("DB_HOST", "localhost")
+    DB_PORT = os.getenv("DB_PORT", "3306")
+    DB_NAME = os.getenv("DB_NAME", "appdb")
+
+    SQLALCHEMY_DATABASE_URI = os.getenv(
+        "DATABASE_URI",
+        f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}",
+    )
+
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY', 'jwt-secret')
+    JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "jwt-secret")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,11 @@ services:
       - "5000:5000"
     environment:
       FLASK_APP: app.main
-      DATABASE_URI: mysql+pymysql://user:password@db:3306/appdb
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_USER: user
+      DB_PASSWORD: password
+      DB_NAME: appdb
       JWT_SECRET_KEY: change-me
     depends_on:
       - db


### PR DESCRIPTION
## Summary
- support MySQL via new environment variables
- update docker-compose to use MySQL vars
- document how to configure the database

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6866f35738a0832cbda4006962d51da3