### PR TITLE
Update flasgger dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ python -m flask db upgrade  # run migrations
 python -m app.main
 ```
 
+This project relies on **Flask 2.3** and requires `flasgger` version
+`0.9.7` or newer. Ensure your dependencies come from the updated
+`requirements.txt` when installing.
+
 After running the application you can access the interactive API documentation
 provided by Swagger at `http://localhost:5000/apidocs/`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ Flask-Cors==3.0.10
 Werkzeug==2.3.0
 Flask-Migrate==4.0.4
 PyJWT==2.6.0
-flasgger==0.9.5
+flasgger>=0.9.7
 PyMySQL==1.1.0


### PR DESCRIPTION
## Summary
- require flasgger >=0.9.7 to work with Flask 2.3
- mention the required version in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686710b72ed4832cae4b3ba2a173c0e6